### PR TITLE
feat: Add Jitpack refresh workflow for main branch

### DIFF
--- a/.github/workflows/jitpack-refresh.yml
+++ b/.github/workflows/jitpack-refresh.yml
@@ -1,0 +1,13 @@
+name: jitpack-refresh.yml
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-jitpack:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Trigger Jitpack build for main SNAPSHOT"
+        run: curl -s -X GET "https://jitpack.io/com/github/aaravmahajanofficial/jenkins-gradle-convention-plugin/main-SNAPSHOT/build.log" >> /dev/null


### PR DESCRIPTION
## Summary
This pull request introduces a new GitHub Actions workflow to trigger Jitpack builds automatically when changes are pushed to the `main` branch.

Workflow addition:

* [`.github/workflows/jitpack-refresh.yml`](diffhunk://#diff-a9e34ac55b7c5d69154d17a2fef21124a8e489a360933acec145a9d7a021cbefR1-R13): Added a new workflow named `jitpack-refresh.yml` that triggers a Jitpack build for the `main-SNAPSHOT` version whenever changes are pushed to the `main` branch. This workflow runs on `ubuntu-latest` and uses a `curl` command to initiate the build.

Fixes #53 

---

## What Changed?
Added jitpack-release.yml

---

## Change Type

- [X] Documentation update
- [X] Build/CI/CD improvement

---

## Developer Checklist

- [X] I reviewed the [CONTRIBUTING](./CONTRIBUTING.md) guidelines
- [X] My code matches the project style and conventions
- [X] All CI checks pass locally
- [X] Documentation is updated where needed
- [X] No new warnings, errors, or linter issues introduced
- [X] Dependent changes are merged & published
- [X] My branch is up to date with target branch
- [X] I spellchecked my code/comments/messages

---
