### PR TITLE
fix: Unresolved reference 'DISPLAY_NAME'

### DIFF
--- a/convention-plugin/src/main/kotlin/utils/GradleVersionUtils.kt
+++ b/convention-plugin/src/main/kotlin/utils/GradleVersionUtils.kt
@@ -26,7 +26,7 @@ public object GradleVersionUtils {
 
         if (currentVersion < requiredVersion) {
             throw GradleException(
-                "${PluginMetadata.DISPLAY_NAME} requires Gradle ${PluginMetadata.MIN_GRADLE_VERSION} or higher. " +
+                "Jenkins Gradle Convention Plugin requires Gradle ${PluginMetadata.MIN_GRADLE_VERSION} or higher. " +
                     "Current version is ${currentVersion.version}. Please upgrade your Gradle version.",
             )
         }


### PR DESCRIPTION
## Summary

This pull request includes a small change to the `GradleVersionUtils` utility in the `convention-plugin` project. The change updates the error message to specify "Jenkins Gradle Convention Plugin" instead of using a generic display name.