### PR TITLE
refactor(ci): Move permissions under the validation job for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,11 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   validation:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
# Description
<!-- What changed, why, and how it fixes the issue. Link issues with `Fixes #<number>`. -->  

Move the permissions block in the validation job, as per CodeQL suggestions.

---

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix — non-breaking change that fixes an issue
- [ ] Feature — non-breaking change adding functionality
- [ ] Breaking change — requires downstream updates/migrations
- [X] Refactoring — no functional changes, code improvements
- [ ] Documentation — changes to docs only
- [ ] Other — describe:

---

## Testing
<!-- Steps for reviewers to verify changes. Include environment/setup if needed. -->  
* N/A

---

## Checklist
<!-- Please check all that apply to this PR using "x". -->
- [X] I reviewed the [CONTRIBUTING](./CONTRIBUTING.md) guidelines and followed project style conventions
- [ ] I added and/or updated tests and confirmed they pass locally
- [ ] I commented code in complex areas
- [ ] I updated documentation where needed
- [X] Changes introduce no new warnings

---

## Additional Notes *(optional)*
<!-- Any extra info for reviewers --> 
