### PR TITLE
refactor: improve the integration-test mock buildScript and configuration-constants

### DIFF
--- a/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
 dependencies {
     implementation(gradleApi())
     implementation(gradleKotlinDsl())
-    compileOnly(libs.findLibrary("kotlin-gradle-plugin").get())
+    implementation(libs.findLibrary("kotlin-gradle-plugin").get())
     implementation(platform(libs.findLibrary("kotlin-bom").get()))
     compileOnly(libs.findLibrary("jetbrains-annotations").get())
 }

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/BomManagementIntegrationTest.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/BomManagementIntegrationTest.kt
@@ -18,7 +18,7 @@
 package io.github.aaravmahajanofficial
 
 import io.github.aaravmahajanofficial.utils.TestProjectBuilder
-import io.github.aaravmahajanofficial.utils.basicPluginConfiguration
+import io.github.aaravmahajanofficial.utils.mockBuildScript
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -40,7 +40,7 @@ class BomManagementIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource()
 
         val result = builder.runGradle("dependencies", "--configuration=runtimeClasspath")
@@ -84,7 +84,7 @@ class BomManagementIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource()
 
         val result = builder.runGradle("dependencies", "--configuration=testRuntimeClasspath")
@@ -105,7 +105,7 @@ class BomManagementIntegrationTest {
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
-                    basicPluginConfiguration(
+                    mockBuildScript(
                         bomBlock =
                             """
                             bom {
@@ -138,7 +138,7 @@ class BomManagementIntegrationTest {
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
-                    basicPluginConfiguration(
+                    mockBuildScript(
                         bomBlock =
                             """
                             bom {
@@ -167,7 +167,7 @@ class BomManagementIntegrationTest {
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
-                    basicPluginConfiguration(
+                    mockBuildScript(
                         bomBlock =
                             """
                             bom {
@@ -196,7 +196,7 @@ class BomManagementIntegrationTest {
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
-                    basicPluginConfiguration(
+                    mockBuildScript(
                         dependenciesBlock =
                             """
                             dependencies {
@@ -229,7 +229,7 @@ class BomManagementIntegrationTest {
                         "bom.jackson.enabled" to "false",
                         "bom.spring.enabled" to "false",
                     ),
-                ).withBuildGradle(basicPluginConfiguration())
+                ).withBuildGradle(mockBuildScript())
                 .withJavaSource()
 
         val result = builder.runGradle("dependencies", "--configuration=runtimeClasspath")

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/FrontendSetupIntegrationTest.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/FrontendSetupIntegrationTest.kt
@@ -16,7 +16,7 @@
 package io.github.aaravmahajanofficial
 
 import io.github.aaravmahajanofficial.utils.TestProjectBuilder
-import io.github.aaravmahajanofficial.utils.basicPluginConfiguration
+import io.github.aaravmahajanofficial.utils.mockBuildScript
 import io.kotest.matchers.paths.shouldExist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -39,7 +39,7 @@ class FrontendSetupIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withPackageJson()
                 .withJavaScriptSource()
 
@@ -60,7 +60,7 @@ class FrontendSetupIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
 
         val result = builder.runGradle("tasks", "--all")
 
@@ -97,7 +97,7 @@ class FrontendSetupIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withSettingsGradle()
                 .withPackageJson(includeTest = false)
                 .withJavaScriptSource()
@@ -115,7 +115,7 @@ class FrontendSetupIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withPackageJson()
                 .withJavaScriptSource()
                 .withJavascriptTestSource()
@@ -138,7 +138,7 @@ class FrontendSetupIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withPackageJson()
                 .withResourceFile()
                 .withJavaScriptSource()

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/PluginApplicationIntegrationTest.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/PluginApplicationIntegrationTest.kt
@@ -18,7 +18,7 @@
 package io.github.aaravmahajanofficial
 
 import io.github.aaravmahajanofficial.utils.TestProjectBuilder
-import io.github.aaravmahajanofficial.utils.basicPluginConfiguration
+import io.github.aaravmahajanofficial.utils.mockBuildScript
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -40,7 +40,7 @@ class PluginApplicationIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource()
 
         val result = builder.runGradle("help")
@@ -58,7 +58,7 @@ class PluginApplicationIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource()
 
         val result = builder.runGradle("tasks", "--group=build")
@@ -77,7 +77,7 @@ class PluginApplicationIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
 
         val result = builder.runGradle("help")
 
@@ -97,7 +97,7 @@ class PluginApplicationIntegrationTest {
                     mapOf(
                         "jenkinsVersion" to "2.520",
                     ),
-                ).withBuildGradle(basicPluginConfiguration())
+                ).withBuildGradle(mockBuildScript())
                 .withJavaSource()
 
         val result = builder.runGradle("jenkinsConventionPluginInfo")
@@ -115,7 +115,7 @@ class PluginApplicationIntegrationTest {
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
-                    basicPluginConfiguration(
+                    mockBuildScript(
                         qualityBlock =
                             """
                             quality {
@@ -147,7 +147,7 @@ class PluginApplicationIntegrationTest {
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
-                    basicPluginConfiguration(
+                    mockBuildScript(
                         dependenciesBlock =
                             """
                             dependencies {
@@ -173,7 +173,7 @@ class PluginApplicationIntegrationTest {
                 .withVersionCatalog()
                 .withSettingsGradle()
                 .withBuildGradle(
-                    basicPluginConfiguration(
+                    mockBuildScript(
                         content =
                             """
                             jenkinsConvention {

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/QualityToolsIntegrationTest.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/QualityToolsIntegrationTest.kt
@@ -18,7 +18,7 @@
 package io.github.aaravmahajanofficial
 
 import io.github.aaravmahajanofficial.utils.TestProjectBuilder
-import io.github.aaravmahajanofficial.utils.basicPluginConfiguration
+import io.github.aaravmahajanofficial.utils.mockBuildScript
 import io.kotest.matchers.paths.shouldExist
 import io.kotest.matchers.shouldBe
 import org.gradle.testkit.runner.TaskOutcome
@@ -40,7 +40,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource()
 
         val result = builder.runGradleAndFail("checkstyleMain")
@@ -65,7 +65,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource()
                 .withConfigFile(
                     toolName = "checkstyle",
@@ -102,7 +102,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource(
                     content =
                         """
@@ -144,7 +144,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource(
                     content =
                         """
@@ -194,7 +194,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource(
                     content =
                         """
@@ -237,7 +237,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withJavaSource(
                     className = "JavaTestClass",
                     content =
@@ -373,7 +373,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withKotlinSource(
                     content =
                         """
@@ -412,7 +412,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withKotlinSource(
                     content =
                         """
@@ -453,7 +453,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withKotlinSource(
                     content =
                         """
@@ -495,7 +495,7 @@ class QualityToolsIntegrationTest {
                 .create()
                 .withVersionCatalog()
                 .withSettingsGradle()
-                .withBuildGradle(basicPluginConfiguration())
+                .withBuildGradle(mockBuildScript())
                 .withKotlinSource(
                     content =
                         """

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/utils/MockBuildScript.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/utils/MockBuildScript.kt
@@ -15,7 +15,7 @@
  */
 package io.github.aaravmahajanofficial.utils
 
-fun basicPluginConfiguration(
+fun mockBuildScript(
     content: String = "",
     bomBlock: String = "",
     qualityBlock: String = "",
@@ -23,7 +23,7 @@ fun basicPluginConfiguration(
 ): String =
     """
     plugins {
-        "kotlin(\"jvm\") version \"2.2.0\""
+        kotlin("jvm") version "2.2.20"
         id("io.github.aaravmahajanofficial.jenkins-gradle-convention-plugin") version "0.0.0-SNAPSHOT"
     }
 

--- a/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/utils/TestProjectBuilder.kt
+++ b/convention-plugin/src/integrationTest/kotlin/io/github/aaravmahajanofficial/utils/TestProjectBuilder.kt
@@ -374,7 +374,7 @@ class TestProjectBuilder(
         private val defaultVersionCatalog =
             """
             [versions]
-            kotlin = "2.2.0"
+            kotlin = "2.2.20"
             kotlinLanguage = "2.2"
             jvmTarget = "21"
             jenkins-core = "2.520"

--- a/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/constants/ConfigurationConstants.kt
+++ b/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/constants/ConfigurationConstants.kt
@@ -18,8 +18,8 @@ package io.github.aaravmahajanofficial.constants
 public object ConfigurationConstants {
     public object Plugin {
         public const val JENKINS_VERSION: String = "jenkinsVersion"
-        public const val TEST_JVM_ARGS: String = "test-jvm-args"
-        public const val NO_TEST_JAR: String = "no-test-jar"
+        public const val TEST_JVM_ARGS: String = "test.jvmargs"
+        public const val PUBLISH_TEST_JAR: String = "publish.testJar"
     }
 
     public object Bom {

--- a/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/extensions/PluginExtension.kt
+++ b/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/extensions/PluginExtension.kt
@@ -16,7 +16,7 @@
 package io.github.aaravmahajanofficial.extensions
 
 import io.github.aaravmahajanofficial.constants.ConfigurationConstants
-import io.github.aaravmahajanofficial.constants.ConfigurationConstants.Plugin.NO_TEST_JAR
+import io.github.aaravmahajanofficial.constants.ConfigurationConstants.Plugin.PUBLISH_TEST_JAR
 import io.github.aaravmahajanofficial.extensions.bom.BomExtension
 import io.github.aaravmahajanofficial.extensions.quality.QualityExtension
 import io.github.aaravmahajanofficial.utils.gradleProperty
@@ -96,11 +96,11 @@ public open class PluginExtension
 
         public val publishTestJar: Property<Boolean> =
             objects.property<Boolean>().convention(
-                gradleProperty(providers, NO_TEST_JAR, String::toBoolean).map { noTestJar -> !noTestJar }.orElse(false),
+                gradleProperty(providers, PUBLISH_TEST_JAR, String::toBoolean).orElse(false),
             )
 
         // Groovy DSL setter methods
-        public fun jenkinsVersions(value: String): Unit = jenkinsVersion.set(value)
+        public fun jenkinsVersion(value: String): Unit = jenkinsVersion.set(value)
 
         public fun artifactId(value: String): Unit = artifactId.set(value)
 

--- a/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/extensions/quality/KoverExtension.kt
+++ b/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/extensions/quality/KoverExtension.kt
@@ -32,7 +32,7 @@ public open class KoverExtension
     ) {
         public val enabled: Property<Boolean> =
             objects.property<Boolean>().convention(
-                gradleProperty(providers, KOVER_ENABLED, String::toBoolean).orElse(true),
+                gradleProperty(providers, KOVER_ENABLED, String::toBoolean).orElse(false),
             )
         public val coverageThreshold: Property<Int> =
             objects.property<Int>().convention(DEFAULT_KOVER_THRESHOLD)


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This pull request focuses on improving the integration tests by replacing the use of the `basicPluginConfiguration` utility with a more flexible `mockBuildScript` utility across all integration test files. Additionally, it updates a dependency configuration in the Gradle build logic to ensure proper dependency resolution. Changed the dependency on `kotlin-gradle-plugin` from `compileOnly` to `implementation` in `kotlin-conventions.gradle.kts` to ensure the plugin is available at runtime, preventing potential issues during build script execution.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code clean-up changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

Verified using existing integration tests. All tests passed :)

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
