### PR TITLE
chore: format plugin name as inline code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jenkins Gradle Convention Plugin
+# `Jenkins Gradle Convention Plugin`
 
 [![CI](https://img.shields.io/github/actions/workflow/status/jenkinsci/gradle-convention-plugin/ci.yml?logo=github&style=for-the-badge&label=CI&labelColor=30363d)](https://github.com/aaravmahajanofficial/jenkins-gradle-convention-plugin/actions/workflows/ci.yml)
 [![Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/io.github.aaravmahajanofficial.jenkins-gradle-convention-plugin?logo=gradle&label=Plugin%20Portal&style=for-the-badge&labelColor=285E61&color=2D8B8B)](https://plugins.gradle.org/plugin/io.github.aaravmahajanofficial.jenkins-gradle-convention-plugin)
@@ -10,7 +10,7 @@
   <img src="docs/img/logo.png" alt="Banner Logo" width="600">
 </p>
 
-The **Jenkins Gradle Convention Plugin** is a Kotlin-first Gradle convention plugin that eliminates boilerplate and standardizes Jenkins plugin development using Gradle. It provides automated quality checks, CI-friendly defaults, and a unified foundation for building, testing, and publishing Jenkins plugins.
+**Jenkins Gradle Convention Plugin** is a Kotlin-first Gradle convention plugin that eliminates boilerplate and standardizes Jenkins plugin development using Gradle. It provides automated quality checks, CI-friendly defaults, and a unified foundation for building, testing, and publishing Jenkins plugins.
 
 Built on the proven [gradle-jpi-plugin](https://github.com/jenkinsci/gradle-jpi-plugin) with enhanced conventions and integrated tooling, so developers can focus on plugin logic rather than build configuration.
 


### PR DESCRIPTION
Updated README to use inline code formatting for the plugin name.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
