### PR TITLE
chore: disable treating all warnings as errors

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -27,7 +27,7 @@ java {
 kotlin {
     explicitApi()
     compilerOptions {
-        allWarningsAsErrors.set(true)
+        allWarningsAsErrors.set(false)
         progressiveMode.set(true)
         optIn.add("kotlin.RequiresOptIn")
         freeCompilerArgs.addAll("-Xjsr305=strict")

--- a/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -30,7 +30,7 @@ java {
 kotlin {
     explicitApi()
     compilerOptions {
-        allWarningsAsErrors.set(true)
+        allWarningsAsErrors.set(false)
         progressiveMode.set(true)
         optIn.add("kotlin.RequiresOptIn")
         jvmDefault.set(JvmDefaultMode.ENABLE)

--- a/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/internal/language/KotlinConfig.kt
+++ b/convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/internal/language/KotlinConfig.kt
@@ -46,7 +46,7 @@ public class KotlinConfig(
 
             project.tasks.withType<KotlinCompile>().configureEach { t ->
                 t.compilerOptions {
-                    allWarningsAsErrors.set(true)
+                    allWarningsAsErrors.set(false)
                     progressiveMode.set(true)
                     optIn.add("kotlin.RequiresOptIn")
                     freeCompilerArgs.addAll(listOf("-Xjsr305=strict"))


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This pull request updates the Kotlin build configuration to no longer treat all compiler warnings as errors. This change is applied consistently across multiple build files to make the build process less strict and prevent warnings from causing build failures.

**Build configuration changes:**

* Set `allWarningsAsErrors` to `false` instead of `true` in the `kotlin` block of `build-logic/build.gradle.kts`, so warnings will not fail the build.
* Set `allWarningsAsErrors` to `false` in the `kotlin` block of `build-logic/src/main/kotlin/kotlin-conventions.gradle.kts`.
* Set `allWarningsAsErrors` to `false` in the `compilerOptions` for Kotlin compile tasks in `convention-plugin/src/main/kotlin/io/github/aaravmahajanofficial/internal/language/KotlinConfig.kt`.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
